### PR TITLE
Add Telegram web app

### DIFF
--- a/appstream-extra/webapps.xml
+++ b/appstream-extra/webapps.xml
@@ -416,4 +416,31 @@
       <value key="X-Kudo-Popular"/>
     </metadata>
   </component>
+  <component type="webapp">
+    <id>epiphany-telegram.desktop</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <name>Telegram</name>
+    <summary>Telegram is an instant messaging app focused on speed and security</summary>
+    <description>
+      <p>
+        Telegram is an instant messaging app focused on speed and security.
+      </p>
+      <p>
+        This webapp provides a quick way to launch a web browser to access
+        Telegram.
+      </p>
+    </description>
+    <icon type="remote">https://web.telegram.org/img/icons/icon128.png</icon>
+    <categories>
+      <category>InstantMessaging</category>
+      <category>Network</category>
+    </categories>
+    <keywords>
+      <keyword>telegram</keyword>
+    </keywords>
+    <url type="homepage">https://telegram.org/</url>
+    <metadata>
+      <value key="X-Kudo-Popular"/>
+    </metadata>
+  </component>
 </components>


### PR DESCRIPTION
Adding a web app for Telegram. Telegram is a popular instant messaging service and we don't have the desktop version in Fedora for numerous reasons of policy, but the web app is just as good as the desktop version.

The description I wrote is a bit lacking, but I didn't want to copy anything from the official description in the Android or Chrome appstore...