### PR TITLE
Link directly to Telegram web client

### DIFF
--- a/appstream-extra/webapps.xml
+++ b/appstream-extra/webapps.xml
@@ -349,7 +349,7 @@
     <id>epiphany-telegram.desktop</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>proprietary</project_license>
-    <name>Telegram</name>
+    <name>Telegram Web</name>
     <summary>Telegram is an instant messaging app focused on speed and security</summary>
     <description>
       <p>
@@ -364,7 +364,8 @@
     <keywords>
       <keyword>telegram</keyword>
     </keywords>
-    <url type="homepage">https://telegram.org/</url>
+    <url type="homepage">https://web.telegram.org/</url>
+    <launchable type="url">https://web.telegram.org/</launchable>
     <metadata>
       <value key="X-Kudo-Popular"/>
     </metadata>


### PR DESCRIPTION
- The Telegram web client is located at https://web.telegram.org/.  Link to it directly.
- Make it clearer that this is the Telegram web client (and not the desktop client that can be acquired elsewhere in RPM or Flatpak form).
- I notice that the AppStream spec defines a [`<launchable>` tag]https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable) which should be used for this purpose.  It’s not supported yet by Gnome Software, but I include it here anyway.