### PR TITLE
make google-chrome.xml pass appstream validation

### DIFF
--- a/appstream-extra/google-chrome.xml
+++ b/appstream-extra/google-chrome.xml
@@ -1,5 +1,5 @@
-<!-- Copyright 2017 The Chromium Authors -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 The Chromium Authors -->
 <components version="0.8" origin="">
   <component type="desktop">
     <id>google-chrome.desktop</id>


### PR DESCRIPTION
This file doesn't pass appstream's validation, and breaks appstream(-qt) based applications if they don't handle errors well.

Moving the comment past the <?xml> tag fixes this.